### PR TITLE
Fixed the calculation of p

### DIFF
--- a/src/leechkit/detector.py
+++ b/src/leechkit/detector.py
@@ -105,7 +105,7 @@ def card_is_leech(
         if canonical_curr_review.button_chosen != 1:
             trial_success_count += 1
 
-    pmg = _fast_poisson_binomial_pmf(trial_probabilities)
+    pmf = _fast_poisson_binomial_pmf(trial_probabilities)
     p = sum(pmf[0:trial_success_count + 1])
 
     if dynamic_threshold:


### PR DESCRIPTION
Also, this is faster than
```
p = 0
for k in range(trial_success_count+1):
    p += poisson_binom.pmf(k, trial_probabilities)
```
![image](https://github.com/user-attachments/assets/3ee61469-1b38-4787-96d8-267cb9ca03af)
