### PR TITLE
Fix R calculation & filter unwanted revlogs

### DIFF
--- a/src/leechkit/detector.py
+++ b/src/leechkit/detector.py
@@ -65,7 +65,7 @@ def card_is_leech(
         elapsed_days = (
             canonical_curr_review.time - canonical_prev_review.time
         ) / SECONDS_PER_DAY
-        stability = canonical_curr_review.memory_state.stability
+        stability = canonical_prev_review.memory_state.stability
 
         r = calculate_fsrs_4_5_retrievability(elapsed_days, stability)
 

--- a/src/leechkit/utils.py
+++ b/src/leechkit/utils.py
@@ -3,6 +3,7 @@ import sys
 from datetime import timezone, date, datetime, tzinfo
 from typing import Final, Optional, Sequence
 
+from anki.stats import REVLOG_CRAM
 from anki.stats_pb2 import CardStatsResponse
 
 SECONDS_PER_DAY: Final[int] = 86_400
@@ -94,6 +95,15 @@ def group_card_reviews_by_day(
 
     grouped_reviews = []
     current_day_reviews: Optional[DayRevLog] = None
+
+    # filter manual revlog entries and reviews done in filtered decks
+    reviews = list(
+        filter(
+            lambda x: x.button_chosen >= 1
+            and (x.review_kind != REVLOG_CRAM or x.ease != 0),
+            reviews,
+        )
+    )
 
     for review in reviews:
         review_effective_date = calculate_review_effective_date(


### PR DESCRIPTION
To calc R at the time of a review, we need
- stability BEFORE the review, and
- days elapsed since the last review

Unless I am misunderstanding this code, this is a bug.